### PR TITLE
fix: timezone issues on notes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agorapulse/angular-calendar",
-  "version": "0.28.16-18",
+  "version": "0.28.16-19",
   "description": "A calendar component for angular 6.0+ that can display events on a month, week or day view",
   "funding": {
     "url": "https://github.com/sponsors/mattlewis92"

--- a/projects/angular-calendar/src/modules/month/calendar-month-row.component.ts
+++ b/projects/angular-calendar/src/modules/month/calendar-month-row.component.ts
@@ -68,17 +68,21 @@ export class CalendarMonthRowComponent implements OnChanges {
         this.timezone
       );
       const notesCopy = this.deepCopyFunction(this.notes);
-      this.currentRowNotes = notesCopy.filter(
-        (note) =>
-          (note.start >= this.startDate && note.start <= this.endDate) ||
-          (note.end >= this.startDate && note.end <= this.endDate) ||
-          (note.start < this.startDate && note.end > this.endDate)
-      );
+      this.currentRowNotes = notesCopy.filter((note: CalendarEvent) => {
+        const startDate: Date = new Date(this.startDate.toDateString());
+        const endDate: Date = new Date(this.endDate.toDateString());
+        return (
+          (note.start >= startDate && note.start <= endDate) ||
+          (note.end >= startDate && note.end <= endDate) ||
+          (note.start < startDate && note.end > endDate)
+        );
+      });
       let index = 0;
       this.daysSliced.forEach((daySliced) => {
-        const currentDay = this.timezoneManager.reverseTz(
-          daySliced.date,
-          this.timezone
+        const currentDay = new Date(
+          this.timezoneManager
+            .reverseTz(daySliced.date, this.timezone)
+            .toDateString()
         );
         const notesOfTheDay = this.currentRowNotes.filter(
           (note) => note.start <= currentDay && note.end >= currentDay
@@ -106,7 +110,7 @@ export class CalendarMonthRowComponent implements OnChanges {
       .map((daySliced) =>
         this.timezoneManager.reverseTz(daySliced.date, this.timezone)
       )
-      .findIndex((date) => date.valueOf() === note.start.valueOf());
+      .findIndex((date) => date.toDateString() === note.start.toDateString());
     let left: number;
     if (dayIndex !== -1) {
       left = dayIndex * (100 / 7);
@@ -149,12 +153,17 @@ export class CalendarMonthRowComponent implements OnChanges {
       .map((daySliced) =>
         this.timezoneManager.reverseTz(daySliced.date, this.timezone)
       )
-      .findIndex((date) => date.valueOf() === note.start.valueOf());
+      .findIndex(
+        (date) =>
+          new Date(date.toDateString()).valueOf() === note.start.valueOf()
+      );
     const indexEndDate = this.daysSliced
       .map((daySliced) =>
         this.timezoneManager.reverseTz(daySliced.date, this.timezone)
       )
-      .findIndex((date) => date.valueOf() === note.end.valueOf());
+      .findIndex(
+        (date) => new Date(date.toDateString()).valueOf() === note.end.valueOf()
+      );
     // start et end dans le row en cours
     if (indexEndDate !== -1 && indexStartDate !== -1) {
       width = (indexEndDate - indexStartDate + 1) * (100 / 7);

--- a/projects/angular-calendar/src/modules/month/calendar-month-view.component.ts
+++ b/projects/angular-calendar/src/modules/month/calendar-month-view.component.ts
@@ -516,10 +516,27 @@ export class CalendarMonthViewComponent
     if (viewEvent && viewNotes) {
       // Merge events & notes
       const tempEvent = viewEvent;
-      let i = 0;
-      tempEvent.days.forEach((day) => {
-        day.events = day.events.concat(viewNotes.days[i].events);
-        i++;
+      // We create a set of the dates without timezones as posts have been calculated with timezones but notes have not
+      const dates: Set<string> = new Set(
+        tempEvent.days
+          .map((day) => day.date.toDateString())
+          .concat(viewNotes.days.map((day) => day.date.toDateString()))
+      );
+      dates.forEach((date) => {
+        if (tempEvent.days.find((day) => day.date.toDateString() === date)) {
+          tempEvent.days
+            .find((day) => day.date.toDateString() === date)
+            .events.concat(
+              viewNotes.days.find((day) => day.date.toDateString() === date)
+                ?.events
+            );
+        } else if (
+          viewNotes.days.find((day) => day.date.toDateString() === date)
+        ) {
+          tempEvent.days.push(
+            viewNotes.days.find((day) => day.date.toDateString() === date)
+          );
+        }
       });
       this.view = tempEvent;
     } else if (this.notes?.length) {


### PR DESCRIPTION
Use toDateString() method on dates in order to remove timezone to handle notes properly.
Create a list of all the dates on which we will loop instead of just looping on event days because there might be a difference between days present in note list and in post list because of this timezone difference